### PR TITLE
Use "instance.metadata.get('modified')" to test instance.modified

### DIFF
--- a/open_graph.py
+++ b/open_graph.py
@@ -51,7 +51,7 @@ def tag_article(instance):
 
     ogtags.append(('article:published_time', strftime(instance.date, "%Y-%m-%d")))
     if instance.metadata.get('modified'):
-        ogtags.append(('article:modified_time', strftime(instance.metadata.get('modified'), "%Y-%m-%d")))
+        ogtags.append(('article:modified_time', strftime(instance.modified, "%Y-%m-%d")))
 
     author_fb_profiles = instance.settings.get('AUTHOR_FB_ID', {})
     if len(author_fb_profiles) > 0:

--- a/open_graph.py
+++ b/open_graph.py
@@ -50,7 +50,8 @@ def tag_article(instance):
     ogtags.append(('og:site_name', instance.settings.get('SITENAME', '')))
 
     ogtags.append(('article:published_time', strftime(instance.date, "%Y-%m-%d")))
-    ogtags.append(('article:modified_time', strftime(instance.modified, "%Y-%m-%d")))
+    if instance.metadata.get('modified'):
+        ogtags.append(('article:modified_time', strftime(instance.metadata.get('modified'), "%Y-%m-%d")))
 
     author_fb_profiles = instance.settings.get('AUTHOR_FB_ID', {})
     if len(author_fb_profiles) > 0:


### PR DESCRIPTION
```
(Pdb) "modified" in dir(instance)
False
```

So we got an in error if using instance.modified.

With the test, if there is no "modified" tag, it will skip inserting `instance.modified` and avoid raising error in output generation.

N.B : There is another approach : using a `try` ... `except`.
