### PR TITLE
Use instance.summary in description

### DIFF
--- a/open_graph.py
+++ b/open_graph.py
@@ -38,7 +38,7 @@ def tag_article(instance):
 
     ogtags.append(('og:description', instance.metadata.get('og_description',
                                                            instance.metadata.get('summary',
-                                                                                 ''))))
+                                                                                 instance.summary))))
 
     default_locale = instance.settings.get('LOCALE', [])
     if default_locale:


### PR DESCRIPTION
This will allow the open_graph parser to take the instance.summary when it can't find it in the metadata. 
Pelican has changed and put the value here.
