### PR TITLE
Add support for og:see_also using the article.related_posts variable (2nd try).

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -25,7 +25,7 @@ article category and from these standard metadata tags:
 - ``modified``
 - ``tags``
 
-Additionaly, the plugin also read these metadata tags:
+Additionally, the plugin also read these metadata tags:
 
 - ``og_image``, an URL to an image that will represent your article;
 - ``og_description``, a short description of your article. If not
@@ -33,3 +33,5 @@ Additionaly, the plugin also read these metadata tags:
   too long;
 - ``og_locale``, the locale of your article (e.g. 'fr_CA'). If not provided,
   the locale will be set to your Pelican settings ``LOCALE``.
+
+Additionally, the plugin reads article.related_posts to set ``og:see_also``.

--- a/open_graph.py
+++ b/open_graph.py
@@ -16,6 +16,7 @@ Use like this in your template:
 """
 from __future__ import unicode_literals
 
+from itertools import chain
 import os.path
 
 from pelican import contents
@@ -49,6 +50,10 @@ def tag_article(instance):
 
     ogtags.append(('og:site_name', instance.settings.get('SITENAME', '')))
 
+    if hasattr(instance, 'related_posts'):
+        for related_post in instance.related_posts:
+            ogtags.append(('og:see_also', related_post.url))
+    
     ogtags.append(('article:published_time', strftime(instance.date, "%Y-%m-%d")))
     
     if hasattr(instance, 'modified'):
@@ -67,10 +72,15 @@ def tag_article(instance):
             ogtags.append(('article:tag', tag.name))
     except AttributeError:
             pass
-
+        
     instance.ogtags = ogtags
 
 
+def tag_articles(generator):
+    for article in chain(generator.articles, generator.drafts):
+        tag_article(article)
+
+
 def register():
-    signals.content_object_init.connect(tag_article)
+    signals.article_generator_finalized.connect(tag_articles)
 

--- a/open_graph.py
+++ b/open_graph.py
@@ -49,6 +49,10 @@ def tag_article(instance):
 
     ogtags.append(('og:site_name', instance.settings.get('SITENAME', '')))
 
+    if hasattr(instance, 'related_posts'):
+        for related_post in instance.related_posts:
+            ogtags.append(('og:see_also', related_post.url))
+    
     ogtags.append(('article:published_time', strftime(instance.date, "%Y-%m-%d")))
     
     if hasattr(instance, 'modified'):
@@ -67,10 +71,15 @@ def tag_article(instance):
             ogtags.append(('article:tag', tag.name))
     except AttributeError:
             pass
-
+        
     instance.ogtags = ogtags
 
 
+def tag_articles(generator):
+    for article in chain(generator.articles, generator.drafts):
+        tag_article(article)
+
+
 def register():
-    signals.content_object_init.connect(tag_article)
+    signals.article_generator_finalized.connect(tag_articles)
 


### PR DESCRIPTION
I've added support for og:see_also using an article.related_posts variable (it exists when pelican-open_graph is loaded after the related_posts plugin). I had to modify the code to use signals.article_generator_finalized because that is how the related_posts plugin has to do it.