### PR TITLE
refactor(python): for flake8, pydocstyle and pylint rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# Needs Xenial, not Trusty for Python 3.7 works:
+# https://travis-ci.community/t/unable-to-download-python-3-7-archive-on-travis-ci/639/2
+# https://github.com/travis-ci/travis-ci/issues/9815#issuecomment-425867404
+dist: xenial
+
+# [INFO] Don't download all repository history, that save a time:
+# https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth
+git:
+  depth: 1
+
+language: python
+
+python: 3.7
+
+install:
+- pip install --upgrade pip
+- pip install flake8 pydocstyle pylint
+
+script:
+- flake8 .
+- pydocstyle
+- pylint .

--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,2 @@
-from .open_graph import *
+"""open_graph initialize."""
+from .open_graph import *  # noqa

--- a/open_graph.py
+++ b/open_graph.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*- #
-"""
-Open Graph
-==========
+"""Open Graph.
 
 This plugin adds Open Graph Protocol tags to articles.
 
@@ -26,13 +24,14 @@ from __future__ import unicode_literals
 
 import os.path
 
-from pelican import generators, signals
-from pelican.utils import strftime
 from bs4 import BeautifulSoup
+from pelican import generators
+from pelican import signals
+from pelican.utils import strftime
 
 
 def open_graph_tag_articles(content_generators):
-
+    """Get different Pelican objects."""
     for generator in content_generators:
         if isinstance(generator, generators.ArticlesGenerator):
             for article in (
@@ -47,8 +46,8 @@ def open_graph_tag_articles(content_generators):
     return True
 
 
-def open_graph_tag(item):
-
+def open_graph_tag(item):  # pylint: disable=too-many-branches
+    """Open Graph items."""
     ogtags = [('og:title', item.title),
               ('og:type', 'article')]
 
@@ -56,16 +55,22 @@ def open_graph_tag(item):
     if image:
         ogtags.append(('og:image', image))
     else:
-        soup = BeautifulSoup(item._content, 'html.parser')
+        soup = BeautifulSoup(
+            item.content,
+            'html.parser')
         img_links = soup.find_all('img')
-        if  (len(img_links) > 0):
+        if img_links:
             img_src = img_links[0].get('src')
-            if not "http" in img_src:
+            if "http" not in img_src:
                 if item.settings.get('SITEURL', ''):
                     img_src = item.settings.get('SITEURL', '') + "/" + img_src
             ogtags.append(('og:image', img_src))
 
-    url = os.path.join(item.settings.get('SITEURL', ''), item.url)
+    url = os.path.join(
+        item.settings.get(
+            'SITEURL',
+            ''),
+        item.url)
     ogtags.append(('og:url', url))
 
     default_summary = item.summary
@@ -84,7 +89,7 @@ def open_graph_tag(item):
 
     if hasattr(item, 'date'):
         ogtags.append(('article:published_time',
-            strftime(item.date, "%Y-%m-%d")))
+                       strftime(item.date, "%Y-%m-%d")))
 
     if hasattr(item, 'modified'):
         ogtags.append(('article:modified_time', strftime(
@@ -92,11 +97,15 @@ def open_graph_tag(item):
 
     if hasattr(item, 'related_posts'):
         for related_post in item.related_posts:
-            url = os.path.join(item.settings.get('SITEURL', ''), related_post.url)
+            url = os.path.join(
+                item.settings.get(
+                    'SITEURL',
+                    ''),
+                related_post.url)
             ogtags.append(('og:see_also', url))
 
     author_fb_profiles = item.settings.get('AUTHOR_FB_ID', {})
-    if len(author_fb_profiles) > 0:
+    if author_fb_profiles:
         for author in item.authors:
             if author.name in author_fb_profiles:
                 ogtags.append(
@@ -114,4 +123,5 @@ def open_graph_tag(item):
 
 
 def register():
+    """Register pelican plugin."""
     signals.all_generators_finalized.connect(open_graph_tag_articles)

--- a/open_graph.py
+++ b/open_graph.py
@@ -78,12 +78,10 @@ def open_graph_tag(item):  # pylint: disable=too-many-branches
     ogtags.append(('og:description', description))
 
     default_locale = item.settings.get('LOCALE', [])
-    if default_locale:
+    if len(default_locale[0]) > 3:
         default_locale = default_locale[0]
-    else:
-        default_locale = ''
-    ogtags.append(
-        ('og:locale', item.metadata.get('og_locale', default_locale)))
+        ogtags.append(
+            ('og:locale', item.metadata.get('og_locale', default_locale)))
 
     ogtags.append(('og:site_name', item.settings.get('SITENAME', '')))
 


### PR DESCRIPTION
### 1. Summary

1. I refactor `open_graph.py` and `__init__.py` files for [**flake8**](https://pypi.org/project/flake8/), [**pydocstyle**](http://www.pydocstyle.org/) and [**pylint**](https://www.pylint.org) rules compatibility.
1. I add `.travis.yml` file for [**Travis CI**](https://travis-ci.org/) flake8, pydocstyle and pylint continuous integration.

### 2. Note

I don't refactor a [**function `open_graph_tag`**](https://github.com/Kristinita/pelican-open_graph/blob/KiraRefactorOpenGraph/open_graph.py#L49), because I'm not sure, that you may not approve significant interference with the code. But I think, that it would be nice fix [**it**](http://pylint.pycqa.org/en/latest/technical_reference/features.html?highlight=R0912#design-checker-messages).

### 3. Testing environment

+ Python 3.7.3
+ Pelican 4.0.1
+ Python Markdown 3.1.1

Thanks.